### PR TITLE
allowed to remove jwt auth header by setting it to null

### DIFF
--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -293,8 +293,9 @@ export default class Frisbee {
   }
 
   jwt(token) {
-
-    if (typeof token === 'string')
+    if (token === null)
+      delete this.headers.Authorization;
+    else if (typeof token === 'string')
       this.headers.Authorization =
         `Bearer ${token}`;
     else


### PR DESCRIPTION
Delete jwt header by setting it to null.

```javascript
api.jwt('my token')
// this.headers.Authorization = `Bearer ${token}`;
api.jwt(null);
// this.headers.Authorization deleted
```