### PR TITLE
Stringify query string parameters for DELETE requests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,7 +204,9 @@ Upon being invoked, `Frisbee` returns an object with the following chainable met
 * All exposed HTTP methods return a Promise, and they require a `path` string, and accept an optional `options` object:
     * Accepted method arguments:
         * `path` **required** - the path for the HTTP request (e.g. `/v1/login`, will be prefixed with the value of `baseURI` mentioned earlier)
-        * `options` _optional_ - an object containing options, such as header values, a request body, form data, or a querystring to send along with the request, here are a few examples (you can override/merge your set default headers as well per request):
+        * `options` _optional_ - an object containing options, such as header values, a request body, form data, or a querystring to send along with the request. For GET and DELETE methods, `body` data will be encoded in the query string.
+
+            Here are a few examples (you can override/merge your set default headers as well per request):
             * To set a custom header value of `X-Reply-To` on a `POST` request:
 
                 ```js

--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -160,7 +160,7 @@ export default class Frisbee {
         if (opts.method === 'POST')
           opts.body = '';
       } else if (typeof opts.body === 'object' || opts.body instanceof Array) {
-        if (opts.method === 'GET') {
+        if (opts.method === 'GET' || opts.method === 'DELETE') {
           path += `?${qs.stringify(opts.body, { arrayFormat: this.arrayFormat })}`;
           delete opts.body;
         } else if (c.get('Content-Type') === 'application/json') {

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -38,6 +38,10 @@ app.get('/querystring', (req, res, next) => {
   res.json(req.query);
 });
 
+app.del('/querystring', (req, res, next) => {
+  res.json(req.query);
+});
+
 app.get('/404', (req, res, next) => {
   res.sendStatus(404);
 });

--- a/test/unit/node.test.js
+++ b/test/unit/node.test.js
@@ -166,21 +166,28 @@ describe('node runtime', () => {
 
   });
 
-  it('should stringify querystring parameters for GET requests', async () => {
+  it('should stringify querystring parameters for GET and DELETE requests', async () => {
     api = new Frisbee(global._options);
     const querystring = {
       a: 'blue',
       b: 'cyan',
       c: 'pink'
     };
-    const res = await api.get('/querystring', {
+    const getRes = await api.get('/querystring', {
       body: querystring
     });
-    expect(res.body).to.be.an('object');
-    expect(res.body).to.deep.equal(querystring);
+    expect(getRes.body).to.be.an('object');
+    expect(getRes.body).to.deep.equal(querystring);
+
+    const delRes = await api.get('/querystring', {
+      body: querystring
+    });
+    expect(delRes.body).to.be.an('object');
+    expect(delRes.body).to.deep.equal(querystring);
   });
 
-  it('should stringify querystring parameters with arrayFormat for GET requests', async () => {
+  it('should stringify querystring parameters with arrayFormat for GET and DELETE requests',
+  async () => {
     api = new Frisbee(Object.assign({}, global._options, {formatArray: 'brackets'}));
     const querystring = {
       a: 'blue',
@@ -192,25 +199,37 @@ describe('node runtime', () => {
         '3'
       ]
     };
-    const res = await api.get('/querystring', {
+    const getRes = await api.get('/querystring', {
       body: querystring
     });
-    expect(res.body).to.be.an('object');
-    expect(res.body).to.deep.equal(querystring);
+    expect(getRes.body).to.be.an('object');
+    expect(getRes.body).to.deep.equal(querystring);
+
+    const delRes = await api.get('/querystring', {
+      body: querystring
+    });
+    expect(delRes.body).to.be.an('object');
+    expect(delRes.body).to.deep.equal(querystring);
   });
 
-  it('should URL encode querystring parameters for GET requests', async () => {
+  it('should URL encode querystring parameters for GET and DELETE requests', async () => {
     api = new Frisbee(global._options);
     const querystring = {
       a: '   ',
       b: '&foo&',
       c: '$$%%%%'
     };
-    const res = await api.get('/querystring', {
+    const getRes = await api.get('/querystring', {
       body: querystring
     });
-    expect(res.body).to.be.an('object');
-    expect(res.body).to.deep.equal(querystring);
+    expect(getRes.body).to.be.an('object');
+    expect(getRes.body).to.deep.equal(querystring);
+
+    const delRes = await api.del('/querystring', {
+      body: querystring
+    });
+    expect(delRes.body).to.be.an('object');
+    expect(delRes.body).to.deep.equal(querystring);
   });
 
   it('should return 404', async () => {


### PR DESCRIPTION
There has been some debate about whether or not DELETE requests should contain payload/body data. From what I gather (from various Stack Overflow discussions), the consensus seems to be that even though the spec doesn't specifically *disallow* it, it's generally discouraged since "[A payload within a DELETE request message has no defined semantics; sending a payload body on a DELETE request might cause some existing implementations to reject the request.](https://tools.ietf.org/html/rfc7231#section-4.3.5)".

Others may have different opinions, but I believe the safest and most common use cases avoid sending body data within DELETE requests. In fact, many web servers and proxies simply drop the body data for DELETE requests, making it unreliable at best.

With that in mind, I propose frisbee change the default behavior when sending DELETE requests to simply treat the request body data the same as GET requests (put the data in the query string). An alternative enhancement/clarification would be separating `body` and `query` parameters in frisbee's request interface.